### PR TITLE
Request accessToken with grant_type as form_param

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -28,7 +28,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://www.linkedin.com/uas/oauth2/accessToken?grant_type=authorization_code';
+        return 'https://www.linkedin.com/uas/oauth2/accessToken';
     }
 
     /**
@@ -70,5 +70,17 @@ class Provider extends AbstractProvider implements ProviderInterface
         ]);
 
         return $this->parseAccessToken($response->getBody());
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return [
+            'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
+            'code' => $code, 'redirect_uri' => $this->redirectUrl,
+            'grant_type' => 'authorization_code'
+        ];
     }
 }


### PR DESCRIPTION
It fixes the 401 bug that the given (valid) access token is not usable for 2~5 mins

``` json
 {
  "errorCode": 0,
  "message": "Unable to verify access token",
  "requestId": "C0DUCX81SA",
  "status": 401,
  "timestamp": 1421946470523
}
```
