### PR TITLE
Use Open ID provider

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -2,11 +2,11 @@
 
 namespace SocialiteProviders\LinkedIn;
 
-use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\LinkedInOpenIdProvider;
 use SocialiteProviders\Manager\ConfigTrait;
 use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 
-class Provider extends LinkedInProvider implements ProviderInterface
+class Provider extends LinkedInOpenIdProvider implements ProviderInterface
 {
     use ConfigTrait;
 


### PR DESCRIPTION
Since August 2023 LinkedIn only uses Open ID for login.